### PR TITLE
Adds dependency for flex in the configure.ac and debian/control files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,12 @@ AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_LIBTOOL
 
+# Checks for flex
+AC_PROG_LEX
+if test "$LEX" != "flex"; then
+        AC_MSG_ERROR(Required program flex not found)
+fi
+
 # Checks for libraries.
 AC_SEARCH_LIBS(dlopen, dl)
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: amplet2
 Section: net
 Priority: optional
 Maintainer: Brendon Jones <brendonj@waikato.ac.nz>
-Build-Depends: debhelper (>= 7.0.50~), autotools-dev, python, libunbound-dev, libssl-dev, libpcap-dev (>= 1.7.4), libyaml-dev, libprotobuf-c-dev, protobuf-c-compiler, protobuf-compiler, dh-systemd, libconfuse-dev, libcurl4-openssl-dev, librabbitmq-dev (>= 0.7.1), libwandevent-dev, python-setuptools
+Build-Depends: debhelper (>= 7.0.50~), autotools-dev, python, libunbound-dev, libssl-dev, libpcap-dev (>= 1.7.4), libyaml-dev, libprotobuf-c-dev, protobuf-c-compiler, protobuf-compiler, dh-systemd, libconfuse-dev, libcurl4-openssl-dev, librabbitmq-dev (>= 0.7.1), libwandevent-dev, python-setuptools, flex
 Standards-Version: 3.8.4
 Homepage: http://amp.wand.net.nz
 #Vcs-Git: git://git.debian.org/collab-maint/amplet2.git


### PR DESCRIPTION
As described in issue #7, this patch adds a dependency for flex in order to make it compile on a clean ubuntu install.

It does this by adding a dependency in the debian/control file, as well as adding a check and error in configure.ac

This will close #7 

There should be no side-effects to this change. This change should not introduce any security issues.