### PR TITLE
Fix issue #3. amp-<test> dumps core on unknown option.

### DIFF
--- a/src/tests/testmain.c
+++ b/src/tests/testmain.c
@@ -64,6 +64,7 @@ struct option long_options[] = {
     {"dns-server", required_argument, 0, '7'},
     {"debug", no_argument, 0, 'x'},
     {"help", no_argument, 0, 'h'},
+    {NULL, 0, 0, 0}
 };
 
 


### PR DESCRIPTION
Fault was testmain.c long_options structure did not NULL terminate the structure array. 

Side-effects: It will stop dumping code.
Security issues: None