### PR TITLE
Fixed the debian build bug

### DIFF
--- a/debian/docs
+++ b/debian/docs
@@ -1,2 +1,2 @@
 NEWS
-README
+README.md

--- a/debian/rules
+++ b/debian/rules
@@ -30,6 +30,7 @@ override_dh_installinit:
 	dh_installinit --no-start
 
 override_dh_auto_configure:
+	$(CURDIR)/bootstrap.sh
 	dh_auto_configure -- $(shell dpkg-buildflags --export=configure)
 
 override_dh_systemd_enable:

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
This fixes #6 (Can't build on clean debian). That turned out to be really simple, one line in debian/rules

debian/rules build failed due to README being
renamed to README.md, so fixed that (debian/docs)

dpkg-buildpackage wanted a nice tarball at the top directory (eg amplet2.blah.tgz).
By changing the package type to native, debian generates the tarball itself. This may not be desired, let me know and I'll resubmit with it as quilt.

There are no expected side-effects of this change.
There are no expected security issues of this change.