### PR TITLE
Long form version of S argument should be schedule to match docs.

### DIFF
--- a/src/tests/throughput/throughput.c
+++ b/src/tests/throughput/throughput.c
@@ -60,7 +60,7 @@ struct option long_options[] =
         {"test-port", required_argument, 0, 'P'},
         {"randomise", no_argument, 0, 'r'},
         {"server", no_argument, 0, 's'},
-        {"sequence", required_argument, 0, 'S'},
+        {"schedule", required_argument, 0, 'S'},
         {"time", required_argument, 0, 't'},
         {"protocol", required_argument, 0, 'u'},
         {"write-size", required_argument, 0, 'z'},


### PR DESCRIPTION
From docs:

`  -S, --schedule       <seq>     Test schedule (see below)`
